### PR TITLE
Disable interpolation of the password field when reading the config file

### DIFF
--- a/mocp-scrobbler.py
+++ b/mocp-scrobbler.py
@@ -430,10 +430,9 @@ def main():
     if kill: return
 
     config = SafeConfigParser()
-
-    try:
-        config.read(configpath)
-    except:
+    config.read(configpath)
+    
+    if not config.has_section('scrobbler'):
         print('Not configured. Edit file: %s' % configpath, file=sys.stderr)
         return 1
 

--- a/mocp-scrobbler.py
+++ b/mocp-scrobbler.py
@@ -436,7 +436,7 @@ def main():
         print('Not configured. Edit file: %s' % configpath, file=sys.stderr)
         return 1
 
-    getter = lambda k, f: config.get('scrobbler', k) if config.has_option('scrobbler', k) else f
+    getter = lambda k, f: config.get('scrobbler', k, raw=True if k == 'password' else False) if config.has_option('scrobbler', k) else f
 
     login = getter('login', None)
     password = getter('password', None)


### PR DESCRIPTION
`SafeConfigParser` enables interpolation of the config parameters by default, which means that any passwords that have a `%` sign inside them will cause a failure of reading the config.
Also, according to documentation of Python 3.1, `config.read()` simply returns an empty config if any of the files on the parameter list are not found, and doesn't throw any exceptions.
